### PR TITLE
Pass arguments to dep command

### DIFF
--- a/cmd/dep.go
+++ b/cmd/dep.go
@@ -17,7 +17,7 @@ var depCmd = &cobra.Command{
 		if verifyFlagVal {
 			return depplugin.Verify()
 		}
-		return depplugin.Run([]string{"ensure"}, cmd.OutOrStdout())
+		return depplugin.Run(append([]string{"ensure"}, args...), cmd.OutOrStdout())
 	},
 }
 


### PR DESCRIPTION
Make it so that, when run in non-verify mode, the arguments
provided to the "dep" command are added after the "ensure"
argument.