### PR TITLE
verify: go back to dep-ensure

### DIFF
--- a/cmd/dep.go
+++ b/cmd/dep.go
@@ -24,6 +24,6 @@ be used before specifying any flags for the "dep" program. For example, "./godel
 }
 
 func init() {
-	depCmd.Flags().BoolVar(&verifyFlagVal, "verify", false, "If --apply=false, runs `dep check`, otherwise runs `dep ensure`")
+	depCmd.Flags().BoolVar(&verifyFlagVal, "verify", false, "verify that `dep ensure` would make no changes")
 	rootCmd.AddCommand(depCmd)
 }

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -157,9 +157,10 @@ func TestDepVerifyApplyFalseFails(t *testing.T) {
 
 	outputBuf = &bytes.Buffer{}
 	runPluginCleanup, err = pluginapitester.RunPlugin(pluginapitester.NewPluginProvider(pluginPath), nil, "dep", []string{"--verify"}, projectDir, false, outputBuf)
+	output := outputBuf.String()
 	defer runPluginCleanup()
-	require.Error(t, err)
-	assert.Equal(t, "Error: # Gopkg.lock is out of sync:\ngithub.com/pkg/errors: imported or required, but missing from Gopkg.lock's input-imports\n\n", outputBuf.String())
+	require.Error(t, err, "expected an error, but finished successfully with output: %s", output)
+	assert.Equal(t, "Error: Would have written Gopkg.lock.\nWould have updated the following projects in the vendor directory:\n\n(0/1) Would have written github.com/pkg/errors@v0.8.0: new project\n", output)
 }
 
 func TestDepVerifyApplyFalseExecErrorFails(t *testing.T) {


### PR DESCRIPTION
`dep check` seems to have issues with symlinks. Let's go back to `dep ensure` for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-dep-plugin/17)
<!-- Reviewable:end -->
